### PR TITLE
sed-feefstock: bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   build:
     - gettext >=0.19.2  # [osx]
   run:
-    - gettext  # [osx]
+    - gettext >=0.19.2  # [osx]
 
 test:
   commands:


### PR DESCRIPTION
I get this with this conda-forge package
```
$ sed
dyld: Library not loaded: @rpath/libintl.8.dylib
  Referenced from: /Users/lecorguille/miniconda3/envs/sed_dist/bin/sed
  Reason: image not found
$ otool -L /Users/lecorguille/miniconda3/envs/sed_dist/bin/sed
/Users/lecorguille/miniconda3/envs/sed_dist/bin/sed:
	@rpath/libintl.8.dylib (compatibility version 10.0.0, current version 10.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1153.18.0)
dyld: Library not loaded: @rpath/libintl.8.dylib
  Referenced from: /Users/lecorguille/miniconda3/envs/sed_dist/bin/sed
  Reason: image not found

```
When I build it on my OSX, it work!
```
$ otool -L /Users/lecorguille/miniconda3/envs/sed_local2/bin/sed
/Users/lecorguille/miniconda3/envs/sed_local2/bin/sed:
	@rpath/libintl.9.dylib (compatibility version 11.0.0, current version 11.4.0)
	@rpath/libiconv.2.dylib (compatibility version 8.0.0, current version 8.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1349.8.0)
```
The upgrade of gettext should fix this issue `0.19.7` -> `0.19.8` !?

Related: https://github.com/galaxyproject/galaxy/pull/4235#discussion_r125673134